### PR TITLE
Add feature to reassign perfclients to CN network nodes

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For a snowflake experiment in directory `tornet-0.1` and the above binaries inst
 
 #### Webtunnel experiments
 
-Snowflake has a client and server binary, each of which should be compiled and installed in a single directory to be passed into ptnettools. This directory should contain each of:
+Webtunnel has a client and server binary, each of which should be compiled and installed in a single directory to be passed into ptnettools. This directory should contain each of:
 - client
 - server
 
@@ -90,6 +90,15 @@ For a webtunnel experiment in directory `tornet-0.1` and the above binaries inst
 ```
 
 Note: these Shadow experiments do not have the fully nginx reverse proxy set up. Clients instead make a direct connection to the Tor bridge. This shouldn't introduce measurable network effects, but should be modified if you want to model a webtunnel bridge that also receives a significant amount of non-circumvention traffic.
+
+### Great bottleneck
+
+There are some facilities to enable great bottleneck experiments:
+
+- You can use the `update-model.py` script to write a new network graph with higher packet loss rates on the network nodes that correspond to CN cities.
+- You can use the `ptnettools.py --china-perf-frac=F` option to reassign fraction F of the perfclients to run inside the CN network nodes.
+
+These steps would be run prior to simulation.
 
 ### Running Shadow simulations
 

--- a/ptnettools.py
+++ b/ptnettools.py
@@ -41,7 +41,7 @@ def main():
         config = webtunnel.update_config(args.path, tor_path, config, args.transport_bin_path)
     else:
         print(f"{args.transport} not supported. Currently supported transports are:\n" + \
-                "obfs4\nsnowflake")
+                "obfs4\nsnowflake\nwebtunnel")
         exit(1)
 
     '''

--- a/ptnettools.py
+++ b/ptnettools.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import random
 from yaml import load, dump
 
 import lyrebird
@@ -22,6 +23,7 @@ def main():
     parser.add_argument('--transport', type=str, help='Name of the transport that is being tested')
     parser.add_argument('--transport-bin-path', type=str, help='Path to the transport binary (or folder containing multiple binaries)')
     parser.add_argument('--transport-stats-path', type=str, help='Path to transport specific metrics file')
+    parser.add_argument('--china-perf-frac', type=float, default=0.0, help='Fraction of torperf clients to reassign to china network nodes')
     args = parser.parse_args()
 
     global config
@@ -41,6 +43,22 @@ def main():
         print(f"{args.transport} not supported. Currently supported transports are:\n" + \
                 "obfs4\nsnowflake")
         exit(1)
+
+    '''
+    There are currently only 6 network nodes in the atlas graph with china country codes.
+    You can grep the atlas file that tornettools uses to find them:
+        $ xzcat {args.path}/conf/atlas_v201801.shadow_v2.gml.xz | grep -B 5 -A 3 CN
+    '''
+    if args.china_perf_frac > 0.0:
+        china_net_ids = [304, 1094, 1568, 2115, 2139, 2423]
+
+        all_perf_clients = [name for name in config['hosts'] if 'perfclient' in name]
+        num_to_reassign = int(len(all_perf_clients) * args.china_perf_frac)
+
+        if num_to_reassign > 0:
+            print(f"Reassigning {num_to_reassign} perfclients to CN network nodes")
+            for name in random.sample(all_perf_clients, num_to_reassign):
+                config['hosts'][name]['network_node_id'] = random.choice(china_net_ids)
 
     print("Overwriting config...")
     with open(args.path+"/shadow.config.yaml", 'w') as f:

--- a/update-model.py
+++ b/update-model.py
@@ -52,6 +52,8 @@ if __name__ == "__main__":
 
     network = read_graph(network_model_path)
     bottleneck_nodes = find_nodes(network, 'CN')
+    print(f"Found {len(bottleneck_nodes)} net ids with a country code of 'CN':")
+    print(bottleneck_nodes)
     network = make_directed(network)
     update_bottleneck_edges(network, bottleneck_nodes)
     write_graph(network)


### PR DESCRIPTION
This reassigns a configurable fraction of perfclients so that they exist in one of the 6 `network_node_id`s currently present in the atlas network graph file that tornettools uses.

I did not adjust the perfclient upstream or downstream bandwidths. Tornettools sets those as:

```
    bandwidth_down: 1000000 kilobit
    bandwidth_up: 1000000 kilobit
```

Those would be easy to change if we want it, but I don't think we want to since the higher link packet loss rates that we would use for the CN network nodes would already effectively give us the bottlenecks we want.